### PR TITLE
add/addMany  function  add  'replace'

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,16 +53,16 @@ module.exports = class Abstract {
    * @param {Object} data
    * @param {Object} options
    */
-  add(data, options) {
-    return this.query.add(data, options);
+  add(data, options, replace) {
+    return this.query.add(data, options, replace);
   }
   /**
    * add data list
    * @param {Array} dataList
    * @param {options} options
    */
-  addMany(dataList, options) {
-    return this.query.addMany(dataList, options);
+  addMany(dataList, options, replace) {
+    return this.query.addMany(dataList, options, replace);
   }
   /**
    * update

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -590,9 +590,10 @@ module.exports = class AbstractParser {
    * get insert sql
    * @param {Object} options
    */
-  buildInsertSql(options) {
+  buildInsertSql(options, replace) {
     const table = this.parseTable(options.table);
-    const insertSql = `INSERT INTO ${table} (${options.fields})`;
+    const sql = replace ? 'REPLACE' : 'INSERT';
+    const insertSql = `${sql} INTO ${table} (${options.fields})`;
     if (helper.isString(options.values)) {
       let values = options.values;
       if (values[0] !== '(') {

--- a/lib/query.js
+++ b/lib/query.js
@@ -47,7 +47,7 @@ module.exports = class AbstractQuery {
    * @param {Object} data
    * @param {Object} options
    */
-  add(data, options) {
+  add(data, options, replace) {
     const values = [];
     const fields = [];
     const parser = this.parser;
@@ -61,7 +61,7 @@ module.exports = class AbstractQuery {
     }
     options.fields = fields.join(',');
     options.values = values.join(',');
-    const sql = this.parser.buildInsertSql(options);
+    const sql = this.parser.buildInsertSql(options, replace);
     return this.execute(sql).then(() => this.lastInsertId);
   }
   /**
@@ -70,7 +70,7 @@ module.exports = class AbstractQuery {
    * @param  {Object} options []
    * @return {Promise}         []
    */
-  addMany(data, options) {
+  addMany(data, options, replace) {
     const parser = this.parser;
     const fields = Object.keys(data[0]).map(item => parser.parseKey(item)).join(',');
     const values = data.map(item => {
@@ -87,7 +87,7 @@ module.exports = class AbstractQuery {
 
     options.fields = fields;
     options.values = values;
-    const sql = this.parser.buildInsertSql(options);
+    const sql = this.parser.buildInsertSql(options, replace);
     return this.execute(sql).then(() => {
       return data.map((item, index) => {
         return this.lastInsertId ? this.lastInsertId + index : 0;


### PR DESCRIPTION
thinkjs2 的 add/addMany 方法有 replace选项，实现replace into 语句，thinkjs3的函数没有这个选项，导致，碰到明确的替代式插入，每次插入前都必须查询一遍，多一次数据库操作，特别是批量插入时，增加的数据语句非常大，比如批量导入含唯一索引的数据、格式化数据表、迁移数据表时，原来只要一条addMany(data, null, true) , 现在都不得不在addMany失败时调用thenUpate一条一条插入，所以强烈建议恢复这个选择项