### PR TITLE
modify package.json: move "babel-preset-think-node" into "devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   },
   "homepage": "https://github.com/thinkjs/think-model-abstract#readme",
   "dependencies": {
-    "babel-preset-think-node": "^1.0.2",
     "debug": "^3.0.0",
     "think-helper": "^1.0.5",
     "think-mysql": "^1.0.2"
   },
   "devDependencies": {
+    "babel-preset-think-node": "^1.0.2",
     "ava": "^0.19.1",
     "eslint": "^4.2.0",
     "eslint-config-think": "^1.0.1",


### PR DESCRIPTION
remove useless dependencies of the production environment.