### PR TITLE
[feature] _complex support Array and complex where

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -162,6 +162,13 @@ module.exports = class AbstractParser {
       str = '( ';
       // _string: ''
       if (['_string', '_complex', '_query'].indexOf(key) > -1) {
+        if (helper.isArray(val)) {
+          result = result.concat(
+            val.map(v => `( ${this.parseThinkWhere(key, v)} )`)
+          );
+          continue;
+        }
+
         str += this.parseThinkWhere(key, val);
       } else if (!keySafeRegExp.test(key)) {
         throw new Error('INVALID_WHERE_CONDITION_KEY');

--- a/test/lib/parser.js
+++ b/test/lib/parser.js
@@ -1061,6 +1061,25 @@ ava.test('parseWhere, complex 4', t => {
   });
   t.is(data, ' WHERE (  ( `id` IN (1,2,3) ) OR ( `content` = \'www\' ) ) AND (  ( `name` = \'lizheming\' ) OR ( `email` = \'lizheming@163.com\' ) OR (  ( `admin` = 1 ) AND ( `status` = 0 ) ) OR (  ( `status` = 1 ) OR ( `ip` = \'127.0.0.1\' ) ) )');
 });
+
+ava.test('parseWhere, complex 5', t => {
+  const instance = getParserInstance();
+  const data = instance.parseWhere({
+    _logic: 'or',
+    _complex: [
+      {
+        start_date: ['<=', '2017-01-01'],
+        end_date: ['>=', '2017-01-01']
+      },
+      {
+        start_date: ['<=', '2017-01-01'],
+        end_date: ['>=', '2017-01-01']
+      }
+    ]
+  });
+  t.is(data, ' WHERE (  ( `start_date` <= \'2017-01-01\' ) AND ( `end_date` >= \'2017-01-01\' ) ) OR (  ( `start_date` <= \'2017-01-01\' ) AND ( `end_date` >= \'2017-01-01\' ) )');
+});
+
 ava.test('parseWhere, other', t => {
   const instance = getParserInstance();
   try {

--- a/test/lib/parser.js
+++ b/test/lib/parser.js
@@ -1031,6 +1031,36 @@ ava.test('parseWhere, complex 3', t => {
   t.is(data, ' WHERE ( `title` = \'test\' ) AND (  ( `id` IN (1,2,3) ) OR ( `content` = \'www\' ) )');
 });
 
+ava.test('parseWhere, complex 4', t => {
+  const instance = getParserInstance();
+  const data = instance.parseWhere({
+    _complex: [
+      {
+        id: ['IN', [1, 2, 3]],
+        content: 'www',
+        _logic: 'or'
+      },
+      {
+        name: 'lizheming',
+        email: 'lizheming@163.com',
+        _logic: 'or',
+        _complex: [
+          {
+            admin: true,
+            status: 0,
+            _logic: 'and'
+          },
+          {
+            status: 1,
+            ip: '127.0.0.1',
+            _logic: 'or'
+          }
+        ]
+      }
+    ]
+  });
+  t.is(data, ' WHERE (  ( `id` IN (1,2,3) ) OR ( `content` = \'www\' ) ) AND (  ( `name` = \'lizheming\' ) OR ( `email` = \'lizheming@163.com\' ) OR (  ( `admin` = 1 ) AND ( `status` = 0 ) ) OR (  ( `status` = 1 ) OR ( `ip` = \'127.0.0.1\' ) ) )');
+});
 ava.test('parseWhere, other', t => {
   const instance = getParserInstance();
   try {


### PR DESCRIPTION
Mention in https://github.com/thinkjs/thinkjs/issues/744 and https://github.com/thinkjs/thinkjs/issues/746 and thinkjs/thinkjs#1201 , after `_complex` support Array, we can support very complex where object than before, like:

```js
this.model('user').where({
    _complex: [
      {
        id: ['IN', [1, 2, 3]],
        content: 'www',
        _logic: 'or'
      },
      {
        name: 'lizheming',
        email: 'lizheming@163.com',
        _logic: 'or',
        _complex: [
          {
            admin: true,
            status: 0,
            _logic: 'and'
          },
          {
            status: 1,
            ip: '127.0.0.1',
            _logic: 'or'
          }
        ]
      }
    ]
  }).select();
```