### PR TITLE
fixBug：parseField function supports empty object parameters

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -51,6 +51,9 @@ module.exports = class AbstractParser {
    * parse field
    * parseField('name');
    * parseField('name,email');
+   * parseField([]);
+   * parseField(['xx_name','xx_email']);
+   * parseField({});
    * parseField({
    *     xx_name: 'name',
    *     xx_email: 'email'
@@ -68,13 +71,13 @@ module.exports = class AbstractParser {
       }
     }
     const alias = options.alias;
-    if (helper.isArray(fields)) {
+    if (helper.isArray(fields) && !helper.isEmpty(fields)) {
       return fields.map(item => {
         item = this.parseKey(item);
         if (alias && item.indexOf('.') === -1) return `${this.parseKey(alias)}.${item}`;
         return item;
       }).join(',');
-    } else if (helper.isObject(fields)) {
+    } else if (helper.isObject(fields) && !helper.isEmpty(fields)) {
       const data = [];
       for (const key in fields) {
         data.push(this.parseKey(key) + ' AS ' + this.parseKey(fields[key]));

--- a/test/lib/parser.js
+++ b/test/lib/parser.js
@@ -129,7 +129,7 @@ ava.test('parseField, empty array', t => {
 
 ava.test('parseField, empty object', t => {
   const instance = getParserInstance();
-  const key = instance.parseField([]);
+  const key = instance.parseField({});
   t.deepEqual(key, '*');
 });
 

--- a/test/lib/parser.js
+++ b/test/lib/parser.js
@@ -120,6 +120,20 @@ ava.test('parseField, empty', t => {
   t.deepEqual(key, '*');
 });
 
+ava.test('parseField, empty array', t => {
+  const instance = getParserInstance();
+  const key = instance.parseField([]);
+  t.deepEqual(key, '*');
+});
+
+
+ava.test('parseField, empty object', t => {
+  const instance = getParserInstance();
+  const key = instance.parseField([]);
+  t.deepEqual(key, '*');
+});
+
+
 ava.test('parseField, single field', t => {
   const instance = getParserInstance();
   const key = instance.parseField('name');


### PR DESCRIPTION
```await this.field([]).where(whereParam).select()````

if field's parameters is a empty object， the parse sql will be  `select  from xxx ` ，then will  be throw a error。